### PR TITLE
added --where option, mostly for config purposes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Command line usage
 
     $ doc8  -h
 
-    usage: doc8 [-h] [--config path] [--allow-long-titles] [--ignore code]
+    usage: doc8 [-h] [--config path] [--where dir] [--allow-long-titles] [--ignore code]
                 [--no-sphinx] [--ignore-path path] [--ignore-path-errors path]
                 [--default-extension extension] [--file-encoding encoding]
                 [--max-line-length int] [-e extension] [-v] [--version]
@@ -54,6 +54,7 @@ Command line usage
       -h, --help            show this help message and exit
       --config path         user config file location (default: doc8.ini, tox.ini,
                             pep8.ini, setup.cfg).
+      --where dir           provide an explicit base directory
       --allow-long-titles   allow long section titles (default: false).
       --ignore code         ignore the given error code(s).
       --no-sphinx           do not ignore sphinx specific false positives.

--- a/doc8/main.py
+++ b/doc8/main.py
@@ -143,6 +143,10 @@ def extract_config(args):
             cfg['extension'] = extensions
     except (configparser.NoSectionError, configparser.NoOptionError):
         pass
+    try:
+        cfg['where'] = parser.get("doc8", "where")
+    except (configparser.NoSectionError, configparser.NoOptionError):
+        pass
     return cfg
 
 
@@ -282,11 +286,14 @@ def main():
     parser.add_argument("paths", metavar='path', type=str, nargs='*',
                         help=("path to scan for doc files"
                               " (default: current directory)."),
-                        default=[os.getcwd()])
+                        default=['.'])
     parser.add_argument("--config", metavar='path', action="append",
                         help="user config file location"
                              " (default: %s)." % default_configs,
                         default=[])
+    parser.add_argument("--where", metavar='dir', action="store",
+                        help="provide an explicit base directory",
+                        default=None)
     parser.add_argument("--allow-long-titles", action="store_true",
                         help="allow long section titles (default: false).",
                         default=False)
@@ -352,6 +359,12 @@ def main():
 
     args.update(cfg)
     setup_logging(args.get('verbose'))
+
+    if args.get('where', None):
+        os.chdir(args['where'])
+    for idx, path in enumerate(args.get('paths', [])):
+        if path == '.':
+            args['paths'][idx] = os.getcwd()
 
     files, files_ignored = scan(args)
     files_selected = len(files)


### PR DESCRIPTION
This allow you to set the "docs" directory in the configuration:

    [doc8]
    where = docs

An open question is whether relative directories passed on the command line (other than '.') should be made absolute *before* changing to "where".